### PR TITLE
fix: page changes to 1 on filter and search [WTEL-2261]

### DIFF
--- a/src/components/history/history-main/registry/history-registry.vue
+++ b/src/components/history/history-main/registry/history-registry.vue
@@ -120,6 +120,12 @@ export default {
         this.loadList();
       },
     },
+    '$store.state.filters': {
+      handler() {
+        this.setPage(1);
+      },
+      deep: true,
+    },
   },
 
   created() {
@@ -147,6 +153,7 @@ export default {
     }),
     ...mapActions('registry', {
       loadList: 'LOAD_DATA_LIST',
+      setPage: 'SET_PAGE',
     }),
     ...mapActions('registry/opened-call', {
       setOpenedItem: 'SET_OPENED_CALL',


### PR DESCRIPTION
Hello,

Пофіксив. 
Здається, що найкращим рішенням для того, щоб не копіпейстити код на всі фільтри і на пошук, буде засетати вотчер на стейт фільтрів, і якщо стейт змінюється - тоді сетати першу сторінку. 
Але якщо такий варіант не дуже (або ти маєш якісь ще ідеї) - то кажи)) 

Дякую.