### PR TITLE
fix: enable vue-tsc typecheck baseline [WTEL-9942]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,8 @@
 				"vite": "npm:rolldown-vite@^7.3.x",
 				"vite-plugin-node-polyfills": "^0.x",
 				"vite-plugin-vue-devtools": "^8.x",
-				"vitest": "^4.x"
+				"vitest": "^4.x",
+				"vue-tsc": "^3.3.7"
 			},
 			"optionalDependencies": {
 				"@esbuild/darwin-arm64": "^0.24.0",
@@ -2569,6 +2570,35 @@
 				"url": "https://opencollective.com/vitest"
 			}
 		},
+		"node_modules/@volar/language-core": {
+			"version": "2.4.28",
+			"resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.28.tgz",
+			"integrity": "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@volar/source-map": "2.4.28"
+			}
+		},
+		"node_modules/@volar/source-map": {
+			"version": "2.4.28",
+			"resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.28.tgz",
+			"integrity": "sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@volar/typescript": {
+			"version": "2.4.28",
+			"resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.28.tgz",
+			"integrity": "sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@volar/language-core": "2.4.28",
+				"path-browserify": "^1.0.1",
+				"vscode-uri": "^3.0.8"
+			}
+		},
 		"node_modules/@vue/babel-helper-vue-transform-on": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@vue/babel-helper-vue-transform-on/-/babel-helper-vue-transform-on-1.5.0.tgz",
@@ -2787,6 +2817,35 @@
 			"license": "MIT",
 			"dependencies": {
 				"rfdc": "^1.4.1"
+			}
+		},
+		"node_modules/@vue/language-core": {
+			"version": "3.3.7",
+			"resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.3.7.tgz",
+			"integrity": "sha512-LzmkKinXAMMoh8Jfi/jMUSDUjuPdv8mynH5WJGKfXyZtDw3hQ6GBaoI6Bcnl/Xqlu32q/0Z6i/trp4VXykzyLw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@volar/language-core": "2.4.28",
+				"@vue/compiler-dom": "^3.5.0",
+				"@vue/shared": "^3.5.0",
+				"alien-signals": "^3.2.1",
+				"muggle-string": "^0.4.1",
+				"path-browserify": "^1.0.1",
+				"picomatch": "^4.0.4"
+			}
+		},
+		"node_modules/@vue/language-core/node_modules/picomatch": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+			"integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
 		"node_modules/@vue/reactivity": {
@@ -3031,9 +3090,9 @@
 			}
 		},
 		"node_modules/@webitel/api-services": {
-			"version": "0.1.46",
-			"resolved": "https://registry.npmjs.org/@webitel/api-services/-/api-services-0.1.46.tgz",
-			"integrity": "sha512-TfHP9t2jXv+ZqWqPFLogHtbtXremZaiaLB18hou8KrTmqcYzj8BY5z8IYufboNOcSy5wWODtERKKrfZbWLjlpQ==",
+			"version": "0.1.53",
+			"resolved": "https://registry.npmjs.org/@webitel/api-services/-/api-services-0.1.53.tgz",
+			"integrity": "sha512-ZPwPR/HRZYuvFkMExPWEmmQNa1AXDhJQWHqsGRDJtva3sXKN/gCpGmMPAY707wA7dtMW+pQaggecd8ik9htlRA==",
 			"dependencies": {
 				"@faker-js/faker": "^9.7.0",
 				"lodash-es": "^4.17.21",
@@ -3089,9 +3148,9 @@
 			}
 		},
 		"node_modules/@webitel/ui-datalist": {
-			"version": "1.1.48",
-			"resolved": "https://registry.npmjs.org/@webitel/ui-datalist/-/ui-datalist-1.1.48.tgz",
-			"integrity": "sha512-S2z+EV6sbshcO3DA4RgiIvS5pH+pSD8y2w5NqM3w1cytSbhYSGtwfqWeW2KRyUSRoELxfG69nTSpQgziRua2Yg==",
+			"version": "1.1.53",
+			"resolved": "https://registry.npmjs.org/@webitel/ui-datalist/-/ui-datalist-1.1.53.tgz",
+			"integrity": "sha512-m7nWgKsAvenXrxUxp4jnaKftUqGcrBfpEwZzg+DD1NLu7lz94FjdR0745VletJvd7Tgoj4dqLbp/2uwC/0pI7A==",
 			"license": "ISC",
 			"workspaces": [
 				"../../",
@@ -3118,9 +3177,9 @@
 			}
 		},
 		"node_modules/@webitel/ui-sdk": {
-			"version": "26.6.101",
-			"resolved": "https://registry.npmjs.org/@webitel/ui-sdk/-/ui-sdk-26.6.101.tgz",
-			"integrity": "sha512-7Wq2V07rFf7weRzdLWl2x8MfyGp0HWv/grItNTtMaJ3Kz8yM/nv9NAtiSt8Ln0I4MgMBKtTUtz8qi5B4/ZKq6Q==",
+			"version": "26.6.104",
+			"resolved": "https://registry.npmjs.org/@webitel/ui-sdk/-/ui-sdk-26.6.104.tgz",
+			"integrity": "sha512-ziBv7vF7RlxxUN6SegIpReW12jpFYHHCSy6H1ZzVr6rfkgq7HDiXHpBm2pSlSH/pJbLyAv7y6Issjshy/B7eGA==",
 			"workspaces": [
 				"./packages/api-services",
 				"./packages/styleguide"
@@ -3243,6 +3302,13 @@
 			"engines": {
 				"node": ">= 6.0.0"
 			}
+		},
+		"node_modules/alien-signals": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-3.2.1.tgz",
+			"integrity": "sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/ansi-escapes": {
 			"version": "7.3.0",
@@ -6868,6 +6934,13 @@
 				}
 			}
 		},
+		"node_modules/muggle-string": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
+			"integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/mute-stream": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
@@ -9367,6 +9440,13 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/vscode-uri": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+			"integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/vue": {
 			"version": "3.5.29",
 			"resolved": "https://registry.npmjs.org/vue/-/vue-3.5.29.tgz",
@@ -9470,6 +9550,23 @@
 			"resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
 			"integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
 			"license": "MIT"
+		},
+		"node_modules/vue-tsc": {
+			"version": "3.3.7",
+			"resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.3.7.tgz",
+			"integrity": "sha512-+C+rgD49wAQ5bUTl2sp5a8Bzg4YoldMNXM+g7CFe604MYcQ8PrZPMQhIjJSzKXtPBCa+C5ayMipqjbA7splekQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@volar/typescript": "2.4.28",
+				"@vue/language-core": "3.3.7"
+			},
+			"bin": {
+				"vue-tsc": "bin/vue-tsc.js"
+			},
+			"peerDependencies": {
+				"typescript": ">=5.0.0"
+			}
 		},
 		"node_modules/vuex": {
 			"version": "4.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3148,9 +3148,9 @@
 			}
 		},
 		"node_modules/@webitel/ui-datalist": {
-			"version": "1.1.53",
-			"resolved": "https://registry.npmjs.org/@webitel/ui-datalist/-/ui-datalist-1.1.53.tgz",
-			"integrity": "sha512-m7nWgKsAvenXrxUxp4jnaKftUqGcrBfpEwZzg+DD1NLu7lz94FjdR0745VletJvd7Tgoj4dqLbp/2uwC/0pI7A==",
+			"version": "1.1.54",
+			"resolved": "https://registry.npmjs.org/@webitel/ui-datalist/-/ui-datalist-1.1.54.tgz",
+			"integrity": "sha512-v133T0XCsFcaF2Rfms3vWK/3LiyDHaMcqzcqGE5O4wty1dE/kJXCjI1GcxIDDgME9qBnMBQ3td92mRetomjzqA==",
 			"license": "ISC",
 			"workspaces": [
 				"../../",
@@ -3177,9 +3177,9 @@
 			}
 		},
 		"node_modules/@webitel/ui-sdk": {
-			"version": "26.6.104",
-			"resolved": "https://registry.npmjs.org/@webitel/ui-sdk/-/ui-sdk-26.6.104.tgz",
-			"integrity": "sha512-ziBv7vF7RlxxUN6SegIpReW12jpFYHHCSy6H1ZzVr6rfkgq7HDiXHpBm2pSlSH/pJbLyAv7y6Issjshy/B7eGA==",
+			"version": "26.6.105",
+			"resolved": "https://registry.npmjs.org/@webitel/ui-sdk/-/ui-sdk-26.6.105.tgz",
+			"integrity": "sha512-q255P2/n+CwEGttwTmRcJNyHznV95pts4M8U1pqo5g5pSye583YD33tn9wWHrzH2shqgNpoQ3fZAg+10ozhdhA==",
 			"workspaces": [
 				"./packages/api-services",
 				"./packages/styleguide"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
 		"prepare": "husky || true",
 		"biome:ci:gh": "biome ci ./src --reporter=github",
 		"test:unit:ci": "vitest run --coverage",
-		"typecheck:ci": "true"
+		"typecheck": "vue-tsc --noEmit -p ./tsconfig.json",
+		"typecheck:ci": "npm run typecheck"
 	},
 	"type": "module",
 	"dependencies": {
@@ -64,7 +65,8 @@
 		"vite": "npm:rolldown-vite@^7.3.x",
 		"vite-plugin-node-polyfills": "^0.x",
 		"vite-plugin-vue-devtools": "^8.x",
-		"vitest": "^4.x"
+		"vitest": "^4.x",
+		"vue-tsc": "^3.3.7"
 	},
 	"optionalDependencies": {
 		"@esbuild/darwin-arm64": "^0.24.0",

--- a/src/app/components/shared/app-header/app-header.vue
+++ b/src/app/components/shared/app-header/app-header.vue
@@ -28,7 +28,6 @@ import {
 	WtAppNavigator,
 	WtHeaderActions,
 	WtLogo,
-	WtNavigationBar,
 } from '@webitel/ui-sdk/components';
 import { WtApplication } from '@webitel/ui-sdk/enums';
 import WtDarkModeSwitcher from '@webitel/ui-sdk/src/modules/Appearance/components/wt-dark-mode-switcher.vue';
@@ -88,7 +87,10 @@ const apps = computed(() => {
 		href: import.meta.env.VITE_CRM_URL,
 	};
 
-	const allApps = [
+	const allApps: {
+		name: WtApplication;
+		href: string | undefined;
+	}[] = [
 		admin,
 		supervisor,
 		agent,

--- a/src/app/components/the-history.vue
+++ b/src/app/components/the-history.vue
@@ -6,8 +6,6 @@
 </template>
 
 <script lang="ts" setup>
-import { WtApplication } from '@webitel/ui-sdk/enums';
-import { computed } from 'vue';
 import { useRegistryStore } from '../../modules/main/modules/registry/store/new/registry.store';
 import AppHeader from './shared/app-header/app-header.vue';
 
@@ -16,11 +14,6 @@ const historyTableStore = useRegistryStore();
 // [https://webitel.atlassian.net/browse/WTEL-6468]
 // Initialize field value to pass a new value to the loadList method, saved from the main table history
 historyTableStore.setupStore();
-
-function goToApplicationHub() {
-	const adminUrl = import.meta.env.VITE_APPLICATION_HUB_URL;
-	window.location.href = adminUrl;
-}
 </script>
 
 <style scoped>

--- a/src/app/router/index.ts
+++ b/src/app/router/index.ts
@@ -1,5 +1,9 @@
 import { WtApplication } from '@webitel/ui-sdk/enums';
-import { createRouter, createWebHistory } from 'vue-router';
+import {
+	createRouter,
+	createWebHistory,
+	type RouteRecordRaw,
+} from 'vue-router';
 import callViewRoute from '../../modules/main/modules/registry/modules/call/router/call-view.ts';
 import CallTabsPathNames from './_internals/CallTabsPathNames.enum.js';
 
@@ -80,7 +84,7 @@ const routes = [
 		name: 'not-found',
 		// component: notFound
 	},
-];
+] as RouteRecordRaw[];
 
 export let router = null;
 
@@ -91,7 +95,7 @@ export const initRouter = async ({
 	router = createRouter({
 		history: createWebHistory(import.meta.env.BASE_URL),
 
-		scrollBehavior(to, from, savedPosition) {
+		scrollBehavior() {
 			return {
 				left: 0,
 				top: 0,
@@ -100,7 +104,7 @@ export const initRouter = async ({
 		routes,
 	});
 
-	router.beforeEach((to, from, next) => {
+	router.beforeEach((to, _from, next) => {
 		if (!localStorage.getItem('access-token') && !to.query.accessToken) {
 			// @author @Lear24
 			// remove flag about shown notifications from localStorage

--- a/src/modules/filters/components/the-history-filters.vue
+++ b/src/modules/filters/components/the-history-filters.vue
@@ -50,13 +50,16 @@ const initializeDefaultCreatedAtFilter = () => {
 initializeDefaultCreatedAtFilter();
 
 const resetFilters = () => {
-	const excludeNotDeletableFilters = filtersOptions.reduce((excludes, opt) => {
-		if (opt?.notDeletable) {
-			excludes.push(opt.name);
-		}
+	const excludeNotDeletableFilters = filtersOptions.reduce<string[]>(
+		(excludes, opt) => {
+			if (typeof opt !== 'string' && opt.notDeletable) {
+				excludes.push(String(opt.name));
+			}
 
-		return excludes;
-	}, []);
+			return excludes;
+		},
+		[],
+	);
 
 	filtersManager.value.reset({
 		exclude: [

--- a/src/modules/filters/components/variable-column-select.vue
+++ b/src/modules/filters/components/variable-column-select.vue
@@ -73,18 +73,16 @@ import {
 	WtBadge,
 	WtButton,
 	WtIconBtn,
-	WtInput,
 	WtPopup,
-	WtTooltip,
 } from '@webitel/ui-sdk/components';
 import { isEmpty } from '@webitel/ui-sdk/scripts';
-import { WtTableHeader } from '@webitel/ui-sdk/src/components/wt-table/types/WtTable.d.ts';
+import type { DatalistTableHeader } from '@webitel/ui-datalist';
 import { computed, reactive, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 const emit = defineEmits<{
 	'update:variable-headers': [
-		value: WtTableHeader[],
+		value: DatalistTableHeader[],
 	];
 }>();
 

--- a/src/modules/filters/components/variable-column-select.vue
+++ b/src/modules/filters/components/variable-column-select.vue
@@ -69,6 +69,7 @@
 <script lang="ts" setup>
 import { useVuelidate } from '@vuelidate/core';
 import { required } from '@vuelidate/validators';
+import type { DatalistTableHeader } from '@webitel/ui-datalist';
 import {
 	WtBadge,
 	WtButton,
@@ -76,7 +77,6 @@ import {
 	WtPopup,
 } from '@webitel/ui-sdk/components';
 import { isEmpty } from '@webitel/ui-sdk/scripts';
-import type { DatalistTableHeader } from '@webitel/ui-datalist';
 import { computed, reactive, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 

--- a/src/modules/heading/components/actions/history-download-action.vue
+++ b/src/modules/heading/components/actions/history-download-action.vue
@@ -22,17 +22,9 @@
 	lang="ts"
 	setup
 >
-import { getCallMediaUrl } from '@webitel/api-services/api';
-import {
-	EngineCallFileType,
-	EngineHistoryCall,
-	EngineTranscriptLookup,
-	StorageListPhrases,
-} from '@webitel/api-services/gen/models';
-import { computed, ref, toRefs } from 'vue';
+import { computed, toRefs } from 'vue';
 import { useI18n } from 'vue-i18n';
 
-import CallTranscriptAPI from '../../../../modules/main/modules/registry/modules/stt/api/callTranscript';
 import { useCallFilesExport } from '../../composables/useCallFilesExport';
 import { useCallTranscriptsExport } from '../../composables/useCallTranscriptsExport';
 import FilesCounter from './files-counter.vue';
@@ -40,7 +32,9 @@ import FilesCounter from './files-counter.vue';
 const props = defineProps<{
 	dataList: Record<string, unknown>[];
 	filters: Record<string, unknown>;
-	selected: Record<string, unknown>[];
+	selected: {
+		id: string;
+	}[];
 }>();
 
 const { filters, selected } = toRefs(props);

--- a/src/modules/heading/components/actions/history-export-action.vue
+++ b/src/modules/heading/components/actions/history-export-action.vue
@@ -26,7 +26,7 @@
             :show-clear="false"
             :label="$t('vocabulary.format')"
             :options="exportSettingOptions"
-            :v="v$.draft?.format"
+            :v="formatValidation"
             :model-value="draft.format"
             required
             @update:model-value="selectHandler"
@@ -35,7 +35,7 @@
             v-if="isExportSettingsFormatCSV"
             v-model:model-value="draft.separator"
             :label="$t('headerSection.exportPopup.separator')"
-            :v="v$.draft?.separator"
+            :v="separatorValidation"
             required
           />
         </div>
@@ -83,7 +83,9 @@ interface Props {
 	dataList: Record<string, unknown>[];
 	filters: Record<string, unknown>;
 	fields: string[];
-	selected: Record<string, unknown>[];
+	selected: {
+		id: string | number;
+	}[];
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -103,7 +105,9 @@ const draft = reactive({
 	separator: '',
 });
 
-const selectedIds = computed(() => selected.value.map((item) => item.id));
+const selectedIds = computed(() =>
+	selected.value.map((item) => Number(item.id)),
+);
 
 const { CSVExportInstance, initCSVExport, exportCSV } = useCSVExport({
 	selected: selectedIds,
@@ -171,9 +175,28 @@ const v$ = useVuelidate(rules, {
 	draft,
 });
 
+// vuelidate exports BaseValidation, but its `[key: string]: any` breaks Vue
+// UnwrapRef / Pick, and computed rules make `v$.value.draft` infer as undefined.
+// Narrow with a minimal shape matching BaseValidation fields we use.
+interface DraftValidation {
+	$touch: () => void;
+	$pending: boolean;
+	$error: boolean;
+	format?: unknown;
+	separator?: unknown;
+}
+
+const draftValidation = computed(
+	() => v$.value.draft as DraftValidation | undefined,
+);
+const formatValidation = computed(() => draftValidation.value?.format);
+const separatorValidation = computed(() => draftValidation.value?.separator);
+
 const disableSaving = computed(() => {
-	v$.value.draft.$touch();
-	return v$.value.draft.$pending || v$.value.draft.$error;
+	const validation = draftValidation.value;
+	if (!validation) return true;
+	validation.$touch();
+	return validation.$pending || validation.$error;
 });
 
 function initXLSExport(

--- a/src/modules/heading/composables/useCallFilesExport.ts
+++ b/src/modules/heading/composables/useCallFilesExport.ts
@@ -24,7 +24,7 @@ export const useCallFilesExport = ({
 					download: true,
 				}),
 			fetch: async ({ page }) => {
-				const params = {
+				const params: Record<string, unknown> = {
 					page,
 					createdAt: {
 						from: 0,

--- a/src/modules/heading/composables/useCallTranscriptsExport.ts
+++ b/src/modules/heading/composables/useCallTranscriptsExport.ts
@@ -40,7 +40,7 @@ export const useCallTranscriptsExport = ({
 				return blob;
 			},
 			fetch: async ({ page }) => {
-				const params = {
+				const params: Record<string, unknown> = {
 					page,
 					createdAt: {
 						from: 0,

--- a/src/modules/main/modules/registry/components/history-registry.vue
+++ b/src/modules/main/modules/registry/components/history-registry.vue
@@ -233,6 +233,7 @@
 <script lang="ts" setup>
 import { getMediaUrl } from '@webitel/api-services/api';
 import { EngineCallFileType } from '@webitel/api-services/gen/models';
+import type { DatalistTableHeader } from '@webitel/ui-datalist';
 import {
 	WtActionBar,
 	WtBadge,
@@ -249,8 +250,8 @@ import {
 	WtVidstackPlayer,
 } from '@webitel/ui-sdk/components';
 import { ComponentSize, IconAction } from '@webitel/ui-sdk/enums';
-import { useTableEmpty } from '@webitel/ui-sdk/src/modules/TableComponentModule/composables/useTableEmpty';
 import { isEmpty } from '@webitel/ui-sdk/scripts';
+import { useTableEmpty } from '@webitel/ui-sdk/src/modules/TableComponentModule/composables/useTableEmpty';
 import get from 'lodash-es/get';
 import { storeToRefs } from 'pinia';
 import { computed, ref, watch } from 'vue';
@@ -261,7 +262,6 @@ import { usePlayMedia } from '../composables/usePlayMedia.ts';
 import SttPopup from '../modules/stt/components/registry/stt-popup.vue';
 import SttAction from '../modules/stt/components/registry/table-stt-action.vue';
 import { useRegistryStore } from '../store/new/registry.store.ts';
-import type { DatalistTableHeader } from '@webitel/ui-datalist';
 import TableDirection from './table-templates/table-direction.vue';
 import ScreenshotsAction from './table-templates/table-screenshots-action.vue';
 

--- a/src/modules/main/modules/registry/components/history-registry.vue
+++ b/src/modules/main/modules/registry/components/history-registry.vue
@@ -248,16 +248,10 @@ import {
 	WtTable,
 	WtVidstackPlayer,
 } from '@webitel/ui-sdk/components';
-import {
-	ChipColor,
-	ComponentSize,
-	IconAction,
-	IconColor,
-} from '@webitel/ui-sdk/enums';
-import { useTableEmpty } from '@webitel/ui-sdk/modules/TableComponentModule/composables/useTableEmpty';
+import { ComponentSize, IconAction } from '@webitel/ui-sdk/enums';
+import { useTableEmpty } from '@webitel/ui-sdk/src/modules/TableComponentModule/composables/useTableEmpty';
 import { isEmpty } from '@webitel/ui-sdk/scripts';
-import { WtTableHeader } from '@webitel/ui-sdk/src/components/wt-table/types/WtTable.d';
-import get from 'lodash/get';
+import get from 'lodash-es/get';
 import { storeToRefs } from 'pinia';
 import { computed, ref, watch } from 'vue';
 import { EngineHistoryCall } from 'webitel-sdk';
@@ -267,6 +261,7 @@ import { usePlayMedia } from '../composables/usePlayMedia.ts';
 import SttPopup from '../modules/stt/components/registry/stt-popup.vue';
 import SttAction from '../modules/stt/components/registry/table-stt-action.vue';
 import { useRegistryStore } from '../store/new/registry.store.ts';
+import type { DatalistTableHeader } from '@webitel/ui-datalist';
 import TableDirection from './table-templates/table-direction.vue';
 import ScreenshotsAction from './table-templates/table-screenshots-action.vue';
 
@@ -286,14 +281,12 @@ const {
 	next,
 	headers,
 	shownHeaders,
-	fields,
 
 	filtersManager,
 	isStoreSetUp,
 } = storeToRefs(tableStore);
 
 const {
-	initialize,
 	loadDataList,
 	updateSelected,
 	updatePage,
@@ -330,8 +323,6 @@ const {
 	headline: emptyHeadline,
 	title: emptyTitle,
 	text: emptyText,
-	primaryActionText: emptyPrimaryActionText,
-	secondaryActionText: emptySecondaryActionText,
 } = useTableEmpty({
 	dataList,
 	error,
@@ -395,8 +386,8 @@ const handleTranscriptDelete = ({
 	);
 };
 
-const updateVariablesHeaders = (variables: WtTableHeader[]) => {
-	const variablesByField = new Map<string, WtTableHeader>(
+const updateVariablesHeaders = (variables: DatalistTableHeader[]) => {
+	const variablesByField = new Map<string, DatalistTableHeader>(
 		variables.map((variable) => [
 			variable.field,
 			variable,

--- a/src/modules/main/modules/registry/components/table-templates/table-screenshots-action.vue
+++ b/src/modules/main/modules/registry/components/table-templates/table-screenshots-action.vue
@@ -29,6 +29,7 @@ interface Props {
 		string,
 		Array<{
 			id: string;
+			name?: string;
 		}>
 	>;
 }

--- a/src/modules/main/modules/registry/composables/usePlayMedia.ts
+++ b/src/modules/main/modules/registry/composables/usePlayMedia.ts
@@ -20,6 +20,7 @@ export const usePlayMedia = () => {
 	const videoData = ref<
 		EngineCallFile & {
 			src: VideoSrc;
+			text?: string;
 		}
 	>();
 
@@ -67,6 +68,7 @@ export const usePlayMedia = () => {
 				src: getCallMediaUrl(mediaFile.id),
 				type: mediaFile.mimeType as VideoMimeType,
 			},
+			text: mediaFile.text,
 		};
 	}
 

--- a/src/modules/main/modules/registry/modules/call/components/call-quality/call-quality.vue
+++ b/src/modules/main/modules/registry/modules/call/components/call-quality/call-quality.vue
@@ -34,16 +34,22 @@
 </template>
 
 <script setup lang="ts">
+import type {
+	EngineHistoryCall,
+	EngineHistoryCallQualityMetrics,
+} from '@webitel/api-services/gen/models';
 import { WtEmpty, WtTable } from '@webitel/ui-sdk/components';
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { EngineHistoryCall } from 'webitel-sdk';
 
 import {
 	headers,
 	QUALITY_PARAMETERS,
 	type QualityParameter,
 } from './store/headers/headers';
+
+type QualityMetricSuffix = 'Avg' | 'Min' | 'MinAt' | 'Max' | 'MaxAt';
+type QualityMetricKey = `${QualityParameter}${QualityMetricSuffix}`;
 
 const props = defineProps<{
 	call: EngineHistoryCall;
@@ -56,17 +62,25 @@ const formatValue = (value?: number) => {
 	return Number(value).toFixed(2);
 };
 
+const getMetric = (
+	metrics: EngineHistoryCallQualityMetrics | undefined,
+	parameter: QualityParameter,
+	suffix: QualityMetricSuffix,
+) => {
+	const key = `${parameter}${suffix}` as QualityMetricKey;
+	return metrics?.[key];
+};
+
 const buildRow = (parameter: QualityParameter) => {
 	const metrics = props.call.qualityMetrics;
-	const prefix = parameter;
 
 	return {
 		parameter,
-		avg: metrics?.[`${prefix}Avg`],
-		min: metrics?.[`${prefix}Min`],
-		minAt: metrics?.[`${prefix}MinAt`],
-		max: metrics?.[`${prefix}Max`],
-		maxAt: metrics?.[`${prefix}MaxAt`],
+		avg: getMetric(metrics, parameter, 'Avg'),
+		min: getMetric(metrics, parameter, 'Min'),
+		minAt: getMetric(metrics, parameter, 'MinAt'),
+		max: getMetric(metrics, parameter, 'Max'),
+		maxAt: getMetric(metrics, parameter, 'MaxAt'),
 	};
 };
 

--- a/src/modules/main/modules/registry/modules/call/components/call-quality/store/headers/headers.ts
+++ b/src/modules/main/modules/registry/modules/call/components/call-quality/store/headers/headers.ts
@@ -1,6 +1,6 @@
-import type { WtTableHeader } from '@webitel/ui-sdk/src/components/wt-table/types/WtTable.type.js';
+import type { DatalistTableHeader } from '@webitel/ui-datalist';
 
-export const headers: WtTableHeader[] = [
+export const headers: DatalistTableHeader[] = [
 	{
 		value: 'parameter',
 		show: true,

--- a/src/modules/main/modules/registry/modules/call/components/call-visualization/call-visualization.vue
+++ b/src/modules/main/modules/registry/modules/call/components/call-visualization/call-visualization.vue
@@ -40,8 +40,8 @@ import CallEvaluation from '../../modules/call-audit/components/call-audit-secti
 import NoCallRecordings from './assets/no-call-recordings.svg';
 import NoCallRecordingsDark from './assets/no-call-recordings-dark.svg';
 import CallScreenRecordings from './screen-recordings/screen-recordings.vue';
-import CallWave from './wave/call-wave.vue';
 import type { CallWaveCallRecord } from './wave/call-wave.types';
+import CallWave from './wave/call-wave.vue';
 
 interface VisualizationTab {
 	text: string;

--- a/src/modules/main/modules/registry/modules/call/components/call-visualization/call-visualization.vue
+++ b/src/modules/main/modules/registry/modules/call/components/call-visualization/call-visualization.vue
@@ -31,7 +31,7 @@
 import { EngineCallFileType } from '@webitel/api-services/gen/models';
 import { WtObject } from '@webitel/ui-sdk/enums';
 import { SpecialGlobalAction } from '@webitel/ui-sdk/modules/Userinfo';
-import { computed, inject, ref } from 'vue';
+import { type Component, computed, inject, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useUserAccessControl } from '../../../../../../../../app/composables/useUserAccessControl';
 import { useUserinfoStore } from '../../../../../../../userinfo/stores/userinfoStore';
@@ -41,9 +41,19 @@ import NoCallRecordings from './assets/no-call-recordings.svg';
 import NoCallRecordingsDark from './assets/no-call-recordings-dark.svg';
 import CallScreenRecordings from './screen-recordings/screen-recordings.vue';
 import CallWave from './wave/call-wave.vue';
+import type { CallWaveCallRecord } from './wave/call-wave.types';
+
+interface VisualizationTab {
+	text: string;
+	component: Component;
+	value: string;
+	namespace: string;
+}
 
 interface Props {
-	call: Record<string, unknown>;
+	call: CallWaveCallRecord & {
+		allowEvaluation?: boolean;
+	};
 	namespace?: string;
 }
 
@@ -67,39 +77,41 @@ const { hasReadAccess: hasEvaluationReadAccess } = useUserAccessControl(
 	WtObject.AuditRating,
 );
 
-const tabValues = computed(() => ({
-	TRANSCRIPT: {
-		text: t('registry.stt.transcription'),
-		component: CallTranscript,
-		value: 'call-transcript',
-		namespace: props.namespace,
-	},
-	EVALUATION: {
-		text: t('registry.call.evaluation.evaluation'),
-		component: CallEvaluation,
-		value: 'call-evaluation',
-		namespace: `${props.namespace}/evaluation`,
-	},
-	SCREEN_RECORDINGS: {
-		text: t('objects.screenRecordings', 2),
-		component: CallScreenRecordings,
-		value: 'call-screen-recordings',
-		namespace: props.namespace,
-	},
-}));
+const tabValues = computed(
+	(): Record<string, VisualizationTab> => ({
+		TRANSCRIPT: {
+			text: t('registry.stt.transcription'),
+			component: CallTranscript,
+			value: 'call-transcript',
+			namespace: props.namespace,
+		},
+		EVALUATION: {
+			text: t('registry.call.evaluation.evaluation'),
+			component: CallEvaluation,
+			value: 'call-evaluation',
+			namespace: `${props.namespace}/evaluation`,
+		},
+		SCREEN_RECORDINGS: {
+			text: t('objects.screenRecordings', 2),
+			component: CallScreenRecordings,
+			value: 'call-screen-recordings',
+			namespace: props.namespace,
+		},
+	}),
+);
 
-const tabs = computed(() => {
-	const tabs = [
+const tabs = computed((): VisualizationTab[] => {
+	const tabList: VisualizationTab[] = [
 		tabValues.value.TRANSCRIPT,
 	];
 	if (props.call.allowEvaluation && hasEvaluationReadAccess.value)
-		tabs.push(tabValues.value.EVALUATION);
+		tabList.push(tabValues.value.EVALUATION);
 	if (isControlAgentScreenAllow.value)
-		tabs.push(tabValues.value.SCREEN_RECORDINGS);
-	return tabs;
+		tabList.push(tabValues.value.SCREEN_RECORDINGS);
+	return tabList;
 });
 
-const currentTab = ref(tabValues.value.TRANSCRIPT);
+const currentTab = ref<VisualizationTab>(tabValues.value.TRANSCRIPT);
 </script>
 
 <style

--- a/src/modules/main/modules/registry/modules/call/components/call-visualization/screen-recordings/screen-recordings.vue
+++ b/src/modules/main/modules/registry/modules/call/components/call-visualization/screen-recordings/screen-recordings.vue
@@ -101,11 +101,18 @@ import getNamespacedState from '@webitel/ui-sdk/src/store/helpers/getNamespacedS
 import { formatDate } from '@webitel/ui-sdk/utils';
 import { computed, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { useStore } from 'vuex';
+import { type Dispatch, useStore } from 'vuex';
 import { useRecordingFilesAccess } from '../../../../../composables/useRecordingFilesAccess';
 
-import { useRegistryStore } from '../../../../../store/new/registry.store.js'; // Не використовується
 import { headers } from './store/headers/headers.js';
+
+interface ScreenRecordingFile {
+	id: string;
+	name?: string;
+	startAt?: string | number;
+	stopAt?: string | number;
+	mime_type?: string;
+}
 
 const props = defineProps({
 	namespace: {
@@ -123,9 +130,9 @@ const dataList = computed(() => {
 
 const error = ref('');
 
-const selected = ref([]);
+const selected = ref<ScreenRecordingFile[]>([]);
 
-const currentVideo = ref(null);
+const currentVideo = ref<ScreenRecordingFile | null>(null);
 const isVideoOpen = ref(false);
 
 const isLoading = computed(() => {
@@ -133,7 +140,7 @@ const isLoading = computed(() => {
 });
 
 const loadDataList = () => {
-	store.dispatch(`${props.namespace}/LOAD_MAIN_CALL`);
+	(store.dispatch as Dispatch)(`${props.namespace}/LOAD_MAIN_CALL`);
 };
 
 const prettifyTimestamp = (item) =>
@@ -146,7 +153,7 @@ const calcDuration = (item) =>
 
 const { hasDeleteAccess } = useRecordingFilesAccess();
 
-const handleDelete = async (items: []) => {
+const handleDelete = async (items: ScreenRecordingFile[]) => {
 	const deleteIds = items.map((item) => item.id);
 	try {
 		FileServicesAPI.delete(deleteIds);
@@ -170,7 +177,9 @@ const {
 	text: textEmpty,
 } = useTableEmpty({
 	dataList,
+	filters: ref({}),
 	error,
+	isLoading,
 });
 
 const openVideo = (item) => {

--- a/src/modules/main/modules/registry/modules/call/components/call-visualization/screen-recordings/store/headers/headers.ts
+++ b/src/modules/main/modules/registry/modules/call/components/call-visualization/screen-recordings/store/headers/headers.ts
@@ -1,6 +1,6 @@
-import type { WtTableHeader } from '@webitel/ui-sdk/src/components/wt-table/types/WtTable.type.js';
+import type { DatalistTableHeader } from '@webitel/ui-datalist';
 
-export const headers: WtTableHeader[] = [
+export const headers: DatalistTableHeader[] = [
 	{
 		value: 'screenRecordings',
 		show: true,

--- a/src/modules/main/modules/registry/modules/call/components/call-visualization/wave/call-wave-comment-form.vue
+++ b/src/modules/main/modules/registry/modules/call/components/call-visualization/wave/call-wave-comment-form.vue
@@ -2,13 +2,13 @@
   <section class="comment-form">
     <wt-timepicker
       v-model:model-value="draft.startSec"
-      :v="v$.draft.startSec"
+      :v="startSecValidation"
       :custom-validators="startCustomValidation"
       :label="$t('reusable.from')"
     />
     <wt-timepicker
       v-model:model-value="draft.endSec"
-      :v="v$.draft.endSec"
+      :v="endSecValidation"
       :custom-validators="endCustomValidation"
       :label="$t('reusable.to')"
     />
@@ -121,9 +121,35 @@ const v$ = useVuelidate(rules, {
 	draft,
 });
 
+// vuelidate exports BaseValidation, but its `[key: string]: any` breaks Vue
+// UnwrapRef / Pick, and computed rules make `v$.value.draft` infer as undefined.
+interface DraftValidation {
+	$touch: () => void;
+	$reset: () => void;
+	$pending: boolean;
+	$invalid: boolean;
+	startSec: {
+		$touch: () => void;
+		$reset: () => void;
+	};
+	endSec: {
+		$touch: () => void;
+		$reset: () => void;
+	};
+}
+
+const draftValidation = computed(
+	() => v$.value.draft as DraftValidation | undefined,
+);
+const startSecValidation = computed(() => draftValidation.value?.startSec);
+const endSecValidation = computed(() => draftValidation.value?.endSec);
+
 const disableSaving = computed(() => {
 	const hasInvalidRange = Number(draft.startSec) > Number(draft.endSec);
-	return v$.value.draft.$pending || v$.value.draft.$invalid || hasInvalidRange;
+	const validation = draftValidation.value;
+	if (!validation) return true;
+
+	return validation.$pending || validation.$invalid || hasInvalidRange;
 });
 
 const customValidation = (minValue: number, maxValue: number) => [
@@ -193,13 +219,17 @@ function emitDraftRange() {
 }
 
 function handleRangeFieldChange(activeField: RangeFieldType) {
-	const inactiveField =
-		activeField === RangeField.StartSec
-			? RangeField.EndSec
-			: RangeField.StartSec;
+	const validation = draftValidation.value;
+	if (!validation) return;
+
 	lastEditedField.value = activeField;
-	v$.value.draft[activeField].$touch();
-	v$.value.draft[inactiveField].$reset();
+	if (activeField === RangeField.StartSec) {
+		validation.startSec.$touch();
+		validation.endSec.$reset();
+	} else {
+		validation.endSec.$touch();
+		validation.startSec.$reset();
+	}
 	emitDraftRange();
 }
 

--- a/src/modules/main/modules/registry/modules/call/components/call-visualization/wave/call-wave.vue
+++ b/src/modules/main/modules/registry/modules/call/components/call-visualization/wave/call-wave.vue
@@ -229,7 +229,10 @@
 <script setup lang="ts">
 import { getCallMediaUrl } from '@webitel/api-services/api';
 import { EngineCallFileType } from '@webitel/api-services/gen/models';
-import { useFilesExport } from '@webitel/ui-sdk/modules/FilesExport';
+import {
+	type ExportedItem,
+	useFilesExport,
+} from '@webitel/ui-sdk/modules/FilesExport';
 import {
 	computed,
 	nextTick,
@@ -386,7 +389,7 @@ const { exportFiles: downloadFile } = useFilesExport({
 		}),
 	fetch: async () => ({
 		items: (props.call.files?.[EngineCallFileType.FileTypeAudio] ??
-			[]) as unknown[],
+			[]) as unknown as ExportedItem[],
 		next: false,
 	}),
 	filename: 'history-record',

--- a/src/modules/main/modules/registry/modules/call/components/video-call-recording/chat-history/_internals/scripts/normalizeMessages.ts
+++ b/src/modules/main/modules/registry/modules/call/components/video-call-recording/chat-history/_internals/scripts/normalizeMessages.ts
@@ -20,7 +20,8 @@ export const normalizeMessages = (
 				url: getMediaUrl(message.file.id),
 			},
 			member: {
-				...message.from,
+				id: message.from?.id ?? '',
+				name: message.from?.name ?? '',
 				self:
 					peers[+message.from?.id - 1].type === 'user' ||
 					peers[+message.from?.id - 1].type === 'bot',

--- a/src/modules/main/modules/registry/modules/call/components/video-call-recording/chat-history/chat-history.vue
+++ b/src/modules/main/modules/registry/modules/call/components/video-call-recording/chat-history/chat-history.vue
@@ -30,10 +30,10 @@
 
 <script setup lang="ts">
 import { MessagesServiceAPI } from '@webitel/api-services/api';
+import type { EngineHistoryCall } from '@webitel/api-services/gen/models';
 import { ChatContainer, ChatMessageType } from '@webitel/ui-chats/ui';
 import { computed, inject, onMounted, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { EngineHistoryCall } from 'webitel-sdk';
 import EmptyChat from './_internals/assets/empty-chat.svg';
 import EmptyChatDark from './_internals/assets/empty-chat-dark.svg';
 import { normalizeMessages } from './_internals/scripts/normalizeMessages';
@@ -75,7 +75,7 @@ const loadNextMessages = async () => {
 			await MessagesServiceAPI.getChatHistory(params);
 		canLoadNextMessages.value = next;
 		normalizedMessages.value = [
-			...normalizeMessages(messages, peers),
+			...(normalizeMessages(messages, peers) as unknown as ChatMessageType[]),
 			...normalizedMessages.value,
 		];
 	} finally {

--- a/src/modules/main/modules/registry/modules/call/components/video-call-recording/pdfs/pdfs.vue
+++ b/src/modules/main/modules/registry/modules/call/components/video-call-recording/pdfs/pdfs.vue
@@ -4,6 +4,7 @@
     :store="tableStore"
     entity-id-key="callId"
     :entity-id-value="callId"
+    :is-created-at-filter="false"
     :access="{
       delete: hasDeleteAccess,
     }"

--- a/src/modules/main/modules/registry/modules/call/components/video-call-recording/screenshots/screenshots.vue
+++ b/src/modules/main/modules/registry/modules/call/components/video-call-recording/screenshots/screenshots.vue
@@ -96,7 +96,10 @@ import {
 } from '@webitel/api-services/api';
 import { EngineCallFileType } from '@webitel/api-services/gen/models';
 import { FormatDateMode, IconAction } from '@webitel/ui-sdk/enums';
-import { useFilesExport } from '@webitel/ui-sdk/modules/FilesExport';
+import {
+	type ExportedItem,
+	useFilesExport,
+} from '@webitel/ui-sdk/modules/FilesExport';
 import { eventBus } from '@webitel/ui-sdk/scripts';
 import DeleteConfirmationPopup from '@webitel/ui-sdk/src/modules/DeleteConfirmationPopup/components/delete-confirmation-popup.vue';
 import { useDeleteConfirmationPopup } from '@webitel/ui-sdk/src/modules/DeleteConfirmationPopup/composables/useDeleteConfirmationPopup';
@@ -112,13 +115,22 @@ import { useRecordingFilesAccess } from '../../../../../composables/useRecording
 
 import { headers } from './store/headers/headers';
 
+interface ScreenshotFile {
+	id: string;
+	name?: string;
+	startAt?: string | number;
+}
+
+type HistoryCallWithFiles = EngineHistoryCall & {
+	files?: Record<string, ScreenshotFile[]>;
+};
+
 interface Props {
-	call: EngineHistoryCall;
+	call: HistoryCallWithFiles;
 	namespace?: string;
 }
 
 const props = withDefaults(defineProps<Props>(), {
-	call: () => [],
 	namespace: '',
 });
 
@@ -140,7 +152,7 @@ const { t } = useI18n();
 
 const error = ref('');
 
-const selected = ref([]);
+const selected = ref<ScreenshotFile[]>([]);
 
 const galleriaVisible = ref(false);
 const galleriaActiveIndex = ref(0);
@@ -175,7 +187,9 @@ const {
 	text: textEmpty,
 } = useTableEmpty({
 	dataList,
+	filters: ref({}),
 	error,
+	isLoading,
 });
 
 const openScreenshot = (id) => {
@@ -185,7 +199,7 @@ const openScreenshot = (id) => {
 	galleriaVisible.value = true;
 };
 
-const handleDelete = async (items: []) => {
+const handleDelete = async (items: ScreenshotFile[]) => {
 	const deleteIds = items.map((item) => item.id);
 
 	await FileServicesAPI.delete(deleteIds);
@@ -221,13 +235,13 @@ const downloadPdf = async () => {
 };
 
 const { exportFiles: downloadZip } = useFilesExport({
-	getFileURL: (item) => getMediaUrl(item.id, false),
-	fetch: () => {
-		const items = selected.value.length ? selected.value : dataList.value;
-		return {
-			items,
-		};
-	},
+	getFileURL: (item) => getMediaUrl(item.id as string, false),
+	fetch: async () => ({
+		items: (selected.value.length
+			? selected.value
+			: dataList.value) as ExportedItem[],
+		next: false,
+	}),
 	filename: `screenshots-callId-${callId.value}`,
 });
 

--- a/src/modules/main/modules/registry/modules/call/components/video-call-recording/video-call-recording.vue
+++ b/src/modules/main/modules/registry/modules/call/components/video-call-recording/video-call-recording.vue
@@ -33,7 +33,7 @@
 
 <script setup lang="ts">
 import { EngineCallFileType } from '@webitel/api-services/gen/models';
-import { computed, onMounted, ref, useTemplateRef } from 'vue';
+import { computed, ref, useTemplateRef } from 'vue';
 import { useI18n } from 'vue-i18n';
 import ChatHistory from './chat-history/chat-history.vue';
 import { useVideoRecordingContentObserver } from './composables/useVideoRecordingContentObserver';

--- a/src/modules/main/modules/registry/modules/call/components/video-call-recording/video-file/video-file.vue
+++ b/src/modules/main/modules/registry/modules/call/components/video-call-recording/video-file/video-file.vue
@@ -76,7 +76,7 @@ interface Props {
 }
 
 const props = withDefaults(defineProps<Props>(), {
-	files: [],
+	files: () => [],
 });
 
 const { t } = useI18n();

--- a/src/modules/main/modules/registry/modules/call/modules/call-audit/api/AuditFormRateAPI.ts
+++ b/src/modules/main/modules/registry/modules/call/modules/call-audit/api/AuditFormRateAPI.ts
@@ -3,7 +3,8 @@ import applyTransform, {
 	notify,
 	snakeToCamel,
 } from '@webitel/ui-sdk/src/api/transformers/index.js';
-import { AuditFormServiceApiFactory, type EngineAuditRate } from 'webitel-sdk';
+import type { EngineAuditRate } from '@webitel/api-services/gen/models';
+import { AuditFormServiceApiFactory } from 'webitel-sdk';
 
 import instance from '../../../../../../../../../app/api/instance';
 import configuration from '../../../../../../../../../app/api/openAPIConfig';
@@ -13,7 +14,7 @@ const auditService = AuditFormServiceApiFactory(configuration, '', instance);
 
 const fillAnswersCreatedAtFromRate = (rate: EngineAuditRate) => ({
 	...rate,
-	answers: rate.answers.map((answer) => ({
+	answers: (rate.answers ?? []).map((answer) => ({
 		...answer,
 		createdAt: rate.createdAt,
 	})),

--- a/src/modules/main/modules/registry/modules/call/modules/call-audit/api/AuditFormRateAPI.ts
+++ b/src/modules/main/modules/registry/modules/call/modules/call-audit/api/AuditFormRateAPI.ts
@@ -1,9 +1,9 @@
+import type { EngineAuditRate } from '@webitel/api-services/gen/models';
 import applyTransform, {
 	camelToSnake,
 	notify,
 	snakeToCamel,
 } from '@webitel/ui-sdk/src/api/transformers/index.js';
-import type { EngineAuditRate } from '@webitel/api-services/gen/models';
 import { AuditFormServiceApiFactory } from 'webitel-sdk';
 
 import instance from '../../../../../../../../../app/api/instance';

--- a/src/modules/main/modules/registry/modules/call/modules/call-audit/components/call-audit-section.vue
+++ b/src/modules/main/modules/registry/modules/call/modules/call-audit/components/call-audit-section.vue
@@ -39,10 +39,11 @@ import { WtObject } from '@webitel/ui-sdk/enums';
 import getNamespacedState from '@webitel/ui-sdk/src/store/helpers/getNamespacedState';
 import { computed, onMounted, ref } from 'vue';
 import { useStore } from 'vuex';
-import { EngineAuditRate } from 'webitel-sdk';
 
 import { useUserAccessControl } from '../../../../../../../../../app/composables/useUserAccessControl';
 import AuditFormAPI from '../api/AuditFormAPI';
+import type { AuditScorecard } from '../types/audit-rate.types';
+import type { EngineAuditRate } from '@webitel/api-services/gen/models';
 import EmptyAuditRate from './empty-audit-rate/empty-audit-rate.vue';
 import SelectScorecardPopup from './empty-audit-rate/select-scorecard-popup.vue';
 import CallAuditForm from './form/call-audit-form.vue';
@@ -59,7 +60,7 @@ const props = defineProps({
 });
 
 const isScorecardSelectOpened = ref(false);
-const scorecard = ref({});
+const scorecard = ref<AuditScorecard>({});
 
 const isEditingEvaluationResult = ref(false);
 
@@ -142,7 +143,7 @@ const saveEvaluationResult = async (evaluationResult: EngineAuditRate) => {
 	}
 };
 
-const setScorecard = (value) => {
+const setScorecard = (value: AuditScorecard) => {
 	scorecard.value = value;
 };
 

--- a/src/modules/main/modules/registry/modules/call/modules/call-audit/components/call-audit-section.vue
+++ b/src/modules/main/modules/registry/modules/call/modules/call-audit/components/call-audit-section.vue
@@ -35,15 +35,14 @@
 </template>
 
 <script lang="ts" setup>
+import type { EngineAuditRate } from '@webitel/api-services/gen/models';
 import { WtObject } from '@webitel/ui-sdk/enums';
 import getNamespacedState from '@webitel/ui-sdk/src/store/helpers/getNamespacedState';
 import { computed, onMounted, ref } from 'vue';
 import { useStore } from 'vuex';
-
 import { useUserAccessControl } from '../../../../../../../../../app/composables/useUserAccessControl';
 import AuditFormAPI from '../api/AuditFormAPI';
 import type { AuditScorecard } from '../types/audit-rate.types';
-import type { EngineAuditRate } from '@webitel/api-services/gen/models';
 import EmptyAuditRate from './empty-audit-rate/empty-audit-rate.vue';
 import SelectScorecardPopup from './empty-audit-rate/select-scorecard-popup.vue';
 import CallAuditForm from './form/call-audit-form.vue';

--- a/src/modules/main/modules/registry/modules/call/modules/call-audit/components/empty-audit-rate/select-scorecard-popup.vue
+++ b/src/modules/main/modules/registry/modules/call/modules/call-audit/components/empty-audit-rate/select-scorecard-popup.vue
@@ -43,8 +43,16 @@ interface Scorecard {
 	questions?: unknown;
 }
 
+interface CallParticipant {
+	id?: string;
+}
+
 interface Props {
-	call: Record<string, unknown>;
+	call: {
+		user?: CallParticipant;
+		from?: CallParticipant;
+		to?: CallParticipant;
+	};
 }
 
 interface Emits {

--- a/src/modules/main/modules/registry/modules/call/modules/call-audit/components/form/call-audit-form.vue
+++ b/src/modules/main/modules/registry/modules/call/modules/call-audit/components/form/call-audit-form.vue
@@ -13,12 +13,12 @@
 </template>
 
 <script lang="ts" setup>
+import type { EngineAuditRate } from '@webitel/api-services/gen/models';
 import AuditForm from '@webitel/ui-sdk/src/modules/AuditForm/components/audit-form.vue';
 import getNamespacedState from '@webitel/ui-sdk/src/store/helpers/getNamespacedState';
 import deepCopy from 'deep-copy';
 import { computed, ref, watch } from 'vue';
 import { useStore } from 'vuex';
-import { EngineAuditRate } from 'webitel-sdk';
 
 const props = defineProps({
 	scorecard: {

--- a/src/modules/main/modules/registry/modules/call/modules/call-audit/components/rate/answers/audit-rate-answer-item.vue
+++ b/src/modules/main/modules/registry/modules/call/modules/call-audit/components/rate/answers/audit-rate-answer-item.vue
@@ -44,7 +44,7 @@
 
     <audit-form-answer-editing-info
       v-if="answer.updatedAt"
-      :answer="answer"
+      :answer="editingInfoAnswer"
       collapsible
     />
   </li>
@@ -72,12 +72,12 @@ const isYesQuestion = computed(
 );
 
 const isAnsweredYesQuestion = computed(
-	() => isYesQuestion.value && props.answer.score > 0,
+	() => isYesQuestion.value && (props.answer.score ?? 0) > 0,
 );
 
 const isAnswerVisible = computed(
 	() =>
-		(!isYesQuestion.value && props.answer.score >= 0) ||
+		(!isYesQuestion.value && (props.answer.score ?? -1) >= 0) ||
 		isAnsweredYesQuestion.value,
 );
 
@@ -91,6 +91,8 @@ const answerName = computed(() => {
 const displayName = computed(() =>
 	isYesQuestion.value ? t('vocabulary.yes') : answerName.value,
 );
+
+const editingInfoAnswer = computed(() => props.answer);
 </script>
 
 <style scoped lang="scss">

--- a/src/modules/main/modules/registry/modules/call/modules/call-audit/components/rate/answers/audit-rate-answers.vue
+++ b/src/modules/main/modules/registry/modules/call/modules/call-audit/components/rate/answers/audit-rate-answers.vue
@@ -10,9 +10,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, defineProps } from 'vue';
-import { EngineAuditRate } from 'webitel-sdk';
-
+import type { EngineAuditRate } from '@webitel/api-services/gen/models';
 import AuditRateAnswerItem from './audit-rate-answer-item.vue';
 
 const props = defineProps<{

--- a/src/modules/main/modules/registry/modules/call/modules/call-audit/components/rate/audit-rate-result.vue
+++ b/src/modules/main/modules/registry/modules/call/modules/call-audit/components/rate/audit-rate-result.vue
@@ -10,7 +10,7 @@
     <audit-rate-summary
       :rate="rate"
       @rate:edit="emit('rate:edit')"
-      @rate:delete="askDeleteConfirmation({ callback: () => emit('rate:delete') })"
+      @rate:delete="askDeleteConfirmation({ deleted: [rate], callback: () => emit('rate:delete') })"
     />
 
     <audit-rate-answers
@@ -22,8 +22,8 @@
 <script lang="ts" setup>
 import DeleteConfirmationPopup from '@webitel/ui-sdk/src/modules/DeleteConfirmationPopup/components/delete-confirmation-popup.vue';
 import { useDeleteConfirmationPopup } from '@webitel/ui-sdk/src/modules/DeleteConfirmationPopup/composables/useDeleteConfirmationPopup';
-import { EngineAuditRate } from 'webitel-sdk';
 
+import type { EngineAuditRate } from '@webitel/api-services/gen/models';
 import AuditRateAnswers from './answers/audit-rate-answers.vue';
 import AuditRateSummary from './summary/audit-rate-summary.vue';
 

--- a/src/modules/main/modules/registry/modules/call/modules/call-audit/components/rate/audit-rate-result.vue
+++ b/src/modules/main/modules/registry/modules/call/modules/call-audit/components/rate/audit-rate-result.vue
@@ -20,10 +20,9 @@
 </template>
 
 <script lang="ts" setup>
+import type { EngineAuditRate } from '@webitel/api-services/gen/models';
 import DeleteConfirmationPopup from '@webitel/ui-sdk/src/modules/DeleteConfirmationPopup/components/delete-confirmation-popup.vue';
 import { useDeleteConfirmationPopup } from '@webitel/ui-sdk/src/modules/DeleteConfirmationPopup/composables/useDeleteConfirmationPopup';
-
-import type { EngineAuditRate } from '@webitel/api-services/gen/models';
 import AuditRateAnswers from './answers/audit-rate-answers.vue';
 import AuditRateSummary from './summary/audit-rate-summary.vue';
 

--- a/src/modules/main/modules/registry/modules/call/modules/call-audit/components/rate/summary/audit-rate-summary-info.vue
+++ b/src/modules/main/modules/registry/modules/call/modules/call-audit/components/rate/summary/audit-rate-summary-info.vue
@@ -28,11 +28,11 @@
 </template>
 
 <script setup lang="ts">
+import type { EngineAuditRate } from '@webitel/api-services/gen/models';
 import { FormatDateMode } from '@webitel/ui-sdk/enums';
 import { formatDate } from '@webitel/ui-sdk/utils';
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { EngineAuditRate } from 'webitel-sdk';
 
 const props = defineProps<{
 	rate: EngineAuditRate;

--- a/src/modules/main/modules/registry/modules/call/modules/call-audit/components/rate/summary/audit-rate-summary.vue
+++ b/src/modules/main/modules/registry/modules/call/modules/call-audit/components/rate/summary/audit-rate-summary.vue
@@ -29,8 +29,10 @@
 </template>
 
 <script lang="ts" setup>
-import type { EngineAuditRate } from '@webitel/api-services/gen/models';
-import { EngineAuditQuestionType } from '@webitel/api-services/gen/models';
+import {
+	EngineAuditQuestionType,
+	type EngineAuditRate,
+} from '@webitel/api-services/gen/models';
 import { WtButton } from '@webitel/ui-sdk/components';
 import { WtObject } from '@webitel/ui-sdk/enums';
 import { computed } from 'vue';

--- a/src/modules/main/modules/registry/modules/call/modules/call-audit/store/evaluation.ts
+++ b/src/modules/main/modules/registry/modules/call/modules/call-audit/store/evaluation.ts
@@ -1,5 +1,5 @@
-import BaseStoreModule from '@webitel/ui-sdk/src/store/BaseStoreModules/BaseStoreModule';
 import type { EngineAuditRate } from '@webitel/api-services/gen/models';
+import BaseStoreModule from '@webitel/ui-sdk/src/store/BaseStoreModules/BaseStoreModule';
 
 import AuditFormRateAPI from '../api/AuditFormRateAPI';
 

--- a/src/modules/main/modules/registry/modules/call/modules/call-audit/store/evaluation.ts
+++ b/src/modules/main/modules/registry/modules/call/modules/call-audit/store/evaluation.ts
@@ -1,10 +1,10 @@
 import BaseStoreModule from '@webitel/ui-sdk/src/store/BaseStoreModules/BaseStoreModule';
-import type { EngineAuditRate } from 'webitel-sdk';
+import type { EngineAuditRate } from '@webitel/api-services/gen/models';
 
 import AuditFormRateAPI from '../api/AuditFormRateAPI';
 
 const state = {
-	result: {}, // todo: rename to auditRate
+	result: {} as EngineAuditRate,
 	isEvaluationLoading: false,
 };
 
@@ -43,8 +43,13 @@ const actions = {
 		}
 	},
 	// todo: rename "evaluation" -> "audit rate"
-	DELETE_EVALUATION: async (context, { id } = {}) => {
-		const rateId = id || context.state.result.id;
+	DELETE_EVALUATION: async (
+		context,
+		payload?: {
+			id?: string;
+		},
+	) => {
+		const rateId = payload?.id || context.state.result.id;
 		context.commit('SET_LOADING', true);
 		try {
 			await AuditFormRateAPI.delete(rateId);

--- a/src/modules/main/modules/registry/modules/call/modules/call-audit/types/audit-rate.types.ts
+++ b/src/modules/main/modules/registry/modules/call/modules/call-audit/types/audit-rate.types.ts
@@ -1,0 +1,5 @@
+export interface AuditScorecard {
+	id?: string;
+	name?: string;
+	questions?: unknown;
+}

--- a/src/modules/main/modules/registry/store/headers/headers.ts
+++ b/src/modules/main/modules/registry/store/headers/headers.ts
@@ -1,6 +1,6 @@
-import type { WtTableHeader } from '@webitel/ui-sdk/src/components/wt-table/types/WtTable.type.js';
+import type { DatalistTableHeader } from '@webitel/ui-datalist';
 
-export const headers: WtTableHeader[] = [
+export const headers: DatalistTableHeader[] = [
 	{
 		value: 'createdAt',
 		show: true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,21 @@
 {
 	"compilerOptions": {
 		"target": "esnext",
-		"lib": ["ES2023", "dom"],
+		"lib": [
+			"ES2023",
+			"dom"
+		],
 		"module": "esnext",
 		"allowJs": true,
 		"skipLibCheck": true,
-		"plugins": [{ "name": "typescript-plugin-css-modules" }],
-		"types": ["vidstack/vue"],
+		"plugins": [
+			{
+				"name": "typescript-plugin-css-modules"
+			}
+		],
+		"types": [
+			"vidstack/vue"
+		],
 		"moduleResolution": "Bundler",
 		"allowImportingTsExtensions": true,
 		"isolatedModules": true,
@@ -17,7 +26,25 @@
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
 		"noFallthroughCasesInSwitch": true,
-		"noUncheckedSideEffectImports": true
+		"noUncheckedSideEffectImports": true,
+
+		"baseUrl": ".",
+		"paths": {
+			"@webitel/ui-sdk/src/*": [
+				"./node_modules/@webitel/ui-sdk/types/*",
+				"./node_modules/@webitel/ui-sdk/src/*"
+			]
+		}
 	},
-	"include": ["src", "docs/pages"]
+	"include": [
+		"src/**/*.ts",
+		"src/**/*.vue",
+		"src/**/*.js"
+	],
+	"exclude": [
+		"**/*.spec.ts",
+		"**/*.spec.js",
+		"**/*.test.ts",
+		"**/*.test.js"
+	]
 }


### PR DESCRIPTION
## Summary
- Enable real `vue-tsc` typecheck (`typecheck` / `typecheck:ci`) instead of stubbing CI
- Clear app type errors using api-services models, exported SDK types, and small local fixes
- Depends on webitel-ui-sdk type fixes from the companion PR (merge/publish SDK before expecting CI typecheck green on published packages alone)

## Test plan
- [ ] `npm run typecheck` exits 0
- [ ] History registry, filters, export actions still work
- [ ] Call audit / quality / visualization / chat history still load
- [ ] After SDK publish: bump `@webitel/ui-sdk` / `@webitel/ui-datalist` if needed and re-run typecheck

Ticket: https://webitel.atlassian.net/browse/WTEL-9942


Made with [Cursor](https://cursor.com)