### PR TITLE
fix: apply restored preset without resetting filters [WTEL-10062]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3148,9 +3148,9 @@
 			}
 		},
 		"node_modules/@webitel/ui-datalist": {
-			"version": "1.1.60",
-			"resolved": "https://registry.npmjs.org/@webitel/ui-datalist/-/ui-datalist-1.1.60.tgz",
-			"integrity": "sha512-hwkcOqtrozobWtDUgc3PzJw8VFUB/3z4EBzho1s7Br2Q18WwyapWSpfIybPCUEPvOO2bqtPJ63UFeePiqE+2+Q==",
+			"version": "1.1.61",
+			"resolved": "https://registry.npmjs.org/@webitel/ui-datalist/-/ui-datalist-1.1.61.tgz",
+			"integrity": "sha512-pAvE76SdWMl+P3hSyl0k2NCrO9BXoeJ8TYA275IPsqZlGcZEtB7MrM9nIr9qVu6wM4ZynANnmtGuuDBrRtlXMQ==",
 			"license": "ISC",
 			"workspaces": [
 				"../../",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
 				"@webitel/styleguide": "~26.2.19",
 				"@webitel/ui-chats": "^0.1.47",
 				"@webitel/ui-datalist": "^1.1.62",
-				"@webitel/ui-sdk": "~26.8.13",
+				"@webitel/ui-sdk": "^26.8.25",
 				"axios": "^1.18.1",
 				"clipboard-copy": "^4.0.1",
 				"date-fns": "^4.1.0",
@@ -3177,9 +3177,9 @@
 			}
 		},
 		"node_modules/@webitel/ui-sdk": {
-			"version": "26.8.24",
-			"resolved": "https://registry.npmjs.org/@webitel/ui-sdk/-/ui-sdk-26.8.24.tgz",
-			"integrity": "sha512-Dl6QENWllIH82wR7ldJYa4qL35o/BAF91VLrj1IYqyTGRzMvAn9Eo7hWWHdoPq/BvK034CcQfdZUNbTGVI0LjA==",
+			"version": "26.8.25",
+			"resolved": "https://registry.npmjs.org/@webitel/ui-sdk/-/ui-sdk-26.8.25.tgz",
+			"integrity": "sha512-Bv30z/n9UOv45GP/dw00bjVoERDgztPV/kgAXQpzcisfIw71dLUTOnjPcYllyKbo67EPnAisojeuAiRCSpdKqQ==",
 			"workspaces": [
 				"./packages/api-services",
 				"./packages/styleguide"

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
 				"@webitel/api-services": "^0.1.54",
 				"@webitel/styleguide": "~26.2.19",
 				"@webitel/ui-chats": "^0.1.47",
-				"@webitel/ui-datalist": "^1.1.60",
+				"@webitel/ui-datalist": "^1.1.62",
 				"@webitel/ui-sdk": "~26.8.13",
 				"axios": "^1.18.1",
 				"clipboard-copy": "^4.0.1",
@@ -3148,9 +3148,9 @@
 			}
 		},
 		"node_modules/@webitel/ui-datalist": {
-			"version": "1.1.61",
-			"resolved": "https://registry.npmjs.org/@webitel/ui-datalist/-/ui-datalist-1.1.61.tgz",
-			"integrity": "sha512-pAvE76SdWMl+P3hSyl0k2NCrO9BXoeJ8TYA275IPsqZlGcZEtB7MrM9nIr9qVu6wM4ZynANnmtGuuDBrRtlXMQ==",
+			"version": "1.1.62",
+			"resolved": "https://registry.npmjs.org/@webitel/ui-datalist/-/ui-datalist-1.1.62.tgz",
+			"integrity": "sha512-wLVTOu5nb1Ne5/ZAsc/syHakw6dnhSzS+ZSLUEeanJxgMgI5NT4meIUY81gm1GE0O1S9gOHJjjbWlWk9kggH9A==",
 			"license": "ISC",
 			"workspaces": [
 				"../../",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"@webitel/styleguide": "~26.2.19",
 		"@webitel/ui-chats": "^0.1.47",
 		"@webitel/ui-datalist": "^1.1.62",
-		"@webitel/ui-sdk": "~26.8.13",
+		"@webitel/ui-sdk": "^26.8.25",
 		"axios": "^1.18.1",
 		"clipboard-copy": "^4.0.1",
 		"date-fns": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"@webitel/api-services": "^0.1.54",
 		"@webitel/styleguide": "~26.2.19",
 		"@webitel/ui-chats": "^0.1.47",
-		"@webitel/ui-datalist": "^1.1.60",
+		"@webitel/ui-datalist": "^1.1.62",
 		"@webitel/ui-sdk": "~26.8.13",
 		"axios": "^1.18.1",
 		"clipboard-copy": "^4.0.1",

--- a/src/modules/filters/components/the-history-filters.vue
+++ b/src/modules/filters/components/the-history-filters.vue
@@ -9,6 +9,7 @@
     @filter:delete="deleteFilter"
     @filter:reset-all="resetFilters"
     @preset:apply="applyPreset"
+    @preset:restore="restorePreset"
     @hide="emit('hide')"
   />
 </template>
@@ -74,9 +75,17 @@ const resetFilters = () => {
 	});
 };
 
+/**
+ * preset cached in localStorage – filters must survive, so no reset here.
+ * `createdAt` is already seeded by initializeDefaultCreatedAtFilter()
+ */
+const restorePreset = (snapshot: string) => {
+	filtersManager.value.fromString(snapshot);
+};
+
 const applyPreset = (snapshot: string) => {
 	resetFilters();
-	filtersManager.value.fromString(snapshot);
+	restorePreset(snapshot);
 };
 </script>
 

--- a/src/modules/filters/components/the-history-filters.vue
+++ b/src/modules/filters/components/the-history-filters.vue
@@ -75,17 +75,17 @@ const resetFilters = () => {
 	});
 };
 
+const applyPreset = (snapshot: string) => {
+	resetFilters();
+	filtersManager.value.fromString(snapshot);
+};
+
 /**
  * preset cached in localStorage – filters must survive, so no reset here.
  * `createdAt` is already seeded by initializeDefaultCreatedAtFilter()
  */
 const restorePreset = (snapshot: string) => {
 	filtersManager.value.fromString(snapshot);
-};
-
-const applyPreset = (snapshot: string) => {
-	resetFilters();
-	restorePreset(snapshot);
 };
 </script>
 


### PR DESCRIPTION
## Description

Depends on webitel/webitel-ui-sdk#1627.

`table-filters-panel` used to emit `preset:apply` both when the user picked a preset and when the preset cached in `localStorage` was restored on mount. `applyPreset` resets filters first, so the cached preset wiped the filters the user arrived with — and because `resetFilters` re-adds `createdAt = Today`, a reload with `createdAt` in the URL jumped back to Today unless the preset itself carried a value.

The SDK now emits a separate `preset:restore` for the cached case. Handle it with a `restorePreset` that only merges the snapshot:

```ts
const restorePreset = (snapshot: string) => {
  filtersManager.value.fromString(snapshot);
};

const applyPreset = (snapshot: string) => {
  resetFilters();
  restorePreset(snapshot);
};
```

`createdAt` is already seeded by `initializeDefaultCreatedAtFilter()` at setup, so the restore path does not need `resetFilters()` to re-add it. Precedence becomes default < route < preset, merge-only. Picking a preset in the popup is unchanged, and `resetFilters` / `initializeDefaultCreatedAtFilter` are untouched.

Note the SDK gates the restore on there being no applied filters, and deliberately ignores `notDeletable` configs when checking — otherwise this repo's seeded `createdAt` would block preset restore permanently.

## Verification

- `npm run typecheck` → exit 0
- `npx biome check` on the changed file → clean

Not yet verified in the browser — needs the SDK change published or linked.

## Related Tasks

* [WTEL-10062](https://webitel.atlassian.net/browse/WTEL-10062)

## Related PR's / Issues

* webitel/webitel-ui-sdk#1627
* webitel/crm#1043

## Todos

- [x] Implementation
- [ ] Bump `@webitel/ui-datalist` once webitel/webitel-ui-sdk#1627 is published

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[WTEL-10062]: https://webitel.atlassian.net/browse/WTEL-10062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ