### PR TITLE
feat(registry): hide the screen recording column without Control agent screen [WTEL-8093]

### DIFF
--- a/src/modules/main/modules/registry/store/headers/headers.ts
+++ b/src/modules/main/modules/registry/store/headers/headers.ts
@@ -1,6 +1,16 @@
 import type { DatalistTableHeader } from '@webitel/ui-datalist';
+import { SpecialGlobalAction } from '@webitel/ui-sdk/modules/Userinfo';
 
-export const headers: DatalistTableHeader[] = [
+import { useUserinfoStore } from '../../../../../userinfo/stores/userinfoStore';
+
+/** Matches how the call visualization already hides its screencast tab. */
+const controlAgentScreenAccess = () =>
+	useUserinfoStore().hasSpecialGlobalActionAccess(
+		SpecialGlobalAction.ControlAgentScreen,
+	);
+
+/* annotated on the literal so a mistyped key is an error, not a silent no-op */
+const rawHeaders: DatalistTableHeader[] = [
 	{
 		value: 'createdAt',
 		show: true,
@@ -155,6 +165,7 @@ export const headers: DatalistTableHeader[] = [
 		sort: undefined,
 		field: 'screencast',
 		locale: 'vocabulary.screencast',
+		access: controlAgentScreenAccess,
 	},
 	{
 		value: 'tags',
@@ -288,7 +299,9 @@ export const headers: DatalistTableHeader[] = [
 		sort: null,
 		field: 'contact',
 	},
-].map((header) => ({
+];
+
+export const headers: DatalistTableHeader[] = rawHeaders.map((header) => ({
 	locale: `fields.${header.value}`,
 	...header,
 }));


### PR DESCRIPTION
[WTEL-8093](https://webitel.atlassian.net/browse/WTEL-8093)

> ⚠️ Depends on webitel/webitel-ui-sdk#1649 — needs a published `@webitel/ui-datalist` carrying the `access` hook before this can be merged or verified in a browser.

## Problem

A user without the **Control agent screen** global action already loses the screencast tab in the call visualization and the screen-recording tabs in Supervisor — but the history registry still offered a **"Запис екрану"** column, and clicking its icon played the recording anyway.

## Change

`screencast` is now gated on `SpecialGlobalAction.ControlAgentScreen`, using the new `access` hook on `DatalistTableHeader`:

```ts
const controlAgentScreenAccess = () =>
	useUserinfoStore().hasSpecialGlobalActionAccess(
		SpecialGlobalAction.ControlAgentScreen,
	);
```

This satisfies both expected results from the ticket:

1. the column is not shown in the registry, and
2. it cannot be added back through the table settings — it is absent from the column picker entirely.

Its field is also never sent to the API, including when a stale `?fields=screencast` is still in the URL or in localStorage.

Nothing else is gated — `access` is optional, and every other header behaves exactly as before. `registry.store.ts` needs no change; `call-legs.vue` derives from the store's `shownHeaders`, so it inherits the filtering.

The header array is now annotated on the literal rather than on the `.map()` result, so a mistyped `access` key would be caught by excess-property checking (see the known gap below for why that isn't active yet).

## Note for the reporter

The ticket's description mentions that a user without the right also loses the **"Знімки екрану"** tab, and the registry has a matching `screenshots` column with the same inconsistency. Since the *expected result* names only "Запис екрану", I left `screenshots` ungated — say the word and it's a one-line follow-up.

## Test plan

- `npm run typecheck` clean; biome clean.
- Manual, once the SDK is published: log in without Control agent screen → "Запис екрану" absent from both the table and the column picker, and `fields` in the history request omits `screencast`. Force `?fields=screencast,created_at` and reload → still hidden, still stripped from the request. Repeat with a full-access role to confirm nothing regressed, and check a call's Legs tab.

### Known gap, pre-existing

`DatalistTableHeader` currently widens to `any` in this repo: ui-datalist's declarations import `@webitel/ui-sdk/components/wt-table/types/WtTable`, which does not resolve under our tsconfig, and `skipLibCheck` hides the error (`any & {...}` collapses to `any`). Verified with a probe — `const x: DatalistTableHeader = 5` raises nothing, while a control error is reported normally.

Practical effect: header definitions get no compile-time checking at all, so a mistyped `access` key would silently fail open. Not introduced here and not fixed here; likely wants a `paths` entry for `@webitel/ui-sdk/components/*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[WTEL-8093]: https://webitel.atlassian.net/browse/WTEL-8093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ