### PR TITLE
ci: wait for published version before updating libs [WTEL-10131]

### DIFF
--- a/.github/workflows/libs.update.yml
+++ b/.github/workflows/libs.update.yml
@@ -15,57 +15,24 @@ on:
           - '@webitel/flow-ui-sdk'
           - '@webitel/styleguide'
 
-permissions:
-  contents: write
+      version:
+        description: 'Version to wait for, e.g. 26.8.34 (see the publish commit message). Leave empty to update to whatever is already published.'
+        required: false
+        type: string
+
+permissions: { contents: read }
 
 jobs:
-  publish:
-    runs-on: [ arc-frontend-runner-set ]
-    steps:
-      - name: Create GitHub App token
-        uses: webitel/reusable-workflows/actions/create-github-app-token@create-github-app-token-v1
-        id: app-token
-        with:
-          client-id: ${{ vars.DELIVERY_BOT_CLIENT_ID }}
-          private-key: ${{ secrets.DELIVERY_BOT_APP_PEM }}
+  update:
+    name: Update lib
+    uses: webitel/reusable-workflows/.github/workflows/frontend-npm-dep-update.yml@v2
+    permissions:
+      id-token: write
+      contents: write
 
-      - name: Checkout repository
-        uses: actions/checkout@v7
-        with:
-          token: ${{ steps.app-token.outputs.token }}
-          persist-credentials: true
+    with:
+      package: ${{ inputs.package }}
+      version: ${{ inputs.version }}
 
-      - name: Configure Git
-        run: |
-          git config user.name '${{ steps.app-token.outputs.user-name }}'
-          git config user.email '${{ steps.app-token.outputs.user-email }}'
-
-      - name: Install deps
-        run: npm ci
-
-      - name: Update selected lib
-        run: |
-          PKG="${{ inputs.package }}"
-          npm update "$PKG"
-          npm ls "$PKG"
-
-      - name: Commit and push changes
-        env:
-          TRIGGERED_BY: ${{ github.actor }}
-          TRIGGERED_BY_ID: ${{ github.actor_id }}
-
-        run: |
-          PKG="${{ inputs.package }}"
-          VERSION=$(npm ls "$PKG" --depth=0 --json | jq -r '.dependencies | to_entries[0].value.version')
-
-          git add package.json
-          if [ -f package-lock.json ]; then
-            git add package-lock.json
-          fi
-
-          git diff --cached --quiet && exit 0
-          CO_AUTHOR_EMAIL="${TRIGGERED_BY_ID}+${TRIGGERED_BY}@users.noreply.github.com"
-          git commit -m "chore(deps): update ${PKG} to v${VERSION}" \
-                     -m "Co-authored-by: ${TRIGGERED_BY} <${CO_AUTHOR_EMAIL}>"
-
-          git push
+    secrets:
+      app-pem: ${{ secrets.DELIVERY_BOT_APP_PEM }}


### PR DESCRIPTION
## Why

npm scans freshly published packages for malware. For a window after `npm publish` returns, the new version is **not yet installable** — the version manifest and/or tarball 404 from the registry.

Our flow is publish-then-immediately-update, so running **Update lib** right after a publish either fails, or — worse — silently succeeds with no change and a green checkmark.

## What

`libs.update.yml` becomes a caller stub. The job itself moved to [webitel/reusable-workflows#4](https://github.com/webitel/reusable-workflows/pull/4), because all 12 consumer copies of this file were **byte-identical** and the fix would otherwise be pasted 12 times.

New optional `version` dispatch input. When given, the workflow waits until that version is actually installable (10 min timeout, 10 s interval) before touching anything, then asserts the repo ended up on it. When left empty, behaviour is identical to today.

The `package` dropdown is untouched — same `choice` select, same six options. It stays on this side because `choice` is only valid for `workflow_dispatch`; `workflow_call` inputs are limited to `string` / `number` / `boolean`, so the reusable workflow takes the package as a plain string.

The update itself stays **unpinned** (`npm update <pkg>`, not `npm i <pkg>@<version>`) — this repo's semver range remains in charge. The version input only gates *when* to proceed.

Two behaviour fixes that come with it:

- **Range-blocked bumps now fail loudly.** `npm update` cannot cross a semver range boundary, so asking for a version this repo's range excludes changed nothing — and `git diff --cached --quiet && exit 0` made that a green run with no commit.
- **`--prefer-online`**, because cached registry metadata is otherwise stale enough to miss a version published minutes ago. Measured: zero extra dependency churn.

## Verification

`actionlint` clean. The reusable workflow's poll loop and assert were exercised against the live registry — see the linked PR.

## Merge order

Depends on [webitel/reusable-workflows#4](https://github.com/webitel/reusable-workflows/pull/4). This stub references `frontend-npm-dep-update.yml@v2`, so **Update lib** here breaks until that PR merges and the `v2` tag moves.

Ticket: [WTEL-10131](https://webitel.atlassian.net/browse/WTEL-10131)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[WTEL-10131]: https://webitel.atlassian.net/browse/WTEL-10131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ